### PR TITLE
Fix availability target example in the Selection Practice

### DIFF
--- a/practices/selection.md
+++ b/practices/selection.md
@@ -51,7 +51,7 @@ Each software service is matched to an availability target via its service expos
 |---|---|---|
 |ecommerce-platform|$810,000|99.9%|
 |appointments|$6,000|95.0%|
-|bedroom|$200,000|99.0%|
+|bedroom|$200,000|99.5%|
 
 The furniture retailer values its financial exposure bands once a quarter. Financial losses from prior incidents are reviewed, and if necessary the financial exposure bands are recalculated. This ensures the risk of financial exposure is revalidated as the business changes.
 


### PR DESCRIPTION
There is a mismatch between the narrative and the financial exposure and availability target table for the furniture retailer example.

The narrative says _the bedroom service is assigned a 99.5% availability target_ but the table mentions an availability target of 99.0% for bedroom.
